### PR TITLE
fix: Add Kotlin and C# extensions to file discovery

### DIFF
--- a/src/agents/dev-agent.ts
+++ b/src/agents/dev-agent.ts
@@ -16,7 +16,21 @@ import { IndexerAgent } from "./indexer-agent.js";
 // Temporarily disable ParserAgent due to web-tree-sitter ESM issues
 import { ParserAgent } from "./parser-agent.js";
 
-const SUPPORTED_CODE_EXTENSIONS = [".js", ".ts", ".jsx", ".tsx", ".py", ".java", ".cpp", ".c", ".go", ".rs"] as const;
+const SUPPORTED_CODE_EXTENSIONS = [
+  ".js",
+  ".ts",
+  ".jsx",
+  ".tsx",
+  ".py",
+  ".java",
+  ".kt",
+  ".kts",
+  ".cpp",
+  ".c",
+  ".go",
+  ".rs",
+  ".cs",
+] as const;
 
 function getDevAgentConfig() {
   const config = getConfig();


### PR DESCRIPTION
## Summary

Quick follow-up to the Kotlin analyzer PR. I was testing it on a real Android project and noticed files weren't being indexed. Turns out `SUPPORTED_CODE_EXTENSIONS` in `dev-agent.ts` was missing the Kotlin extensions.

The Kotlin analyzer itself works great, but the DevAgent filters files by extension *before* they reach the parser. So `.kt` and `.kts` files were getting skipped during directory walking.

## The issue

```typescript
// Was missing .kt, .kts, and .cs
const SUPPORTED_CODE_EXTENSIONS = [".js", ".ts", ".jsx", ".tsx", ".py", ".java", ".cpp", ".c", ".go", ".rs"]
```

## The fix

Added `.kt`, `.kts`, and `.cs` to the array:

```typescript
const SUPPORTED_CODE_EXTENSIONS = [".js", ".ts", ".jsx", ".tsx", ".py", ".java", ".kt", ".kts", ".cpp", ".c", ".go", ".rs", ".cs"]
```

## Testing

Tested on an Android/Kotlin project (77 source files):
- **Before:** Only 6 files indexed (non-Kotlin files)
- **After:** All 77 files indexed, 1,525 entities extracted

## Why this happened

There are two places that control language support:
1. `language-configs.ts` → `FILE_EXTENSIONS` (for parsing) ✅ already had `kt`/`kts`
2. `dev-agent.ts` → `SUPPORTED_CODE_EXTENSIONS` (for file discovery) ❌ was missing them

They got out of sync. Might be worth consolidating these in the future so they can't drift apart.